### PR TITLE
&[u8]: RevRead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "buf-reader-plus"
+name = "rev_read"
 version = "0.1.0"
 edition = "2021"
 authors = ["TornaxO7 <tornax@pm.me>"]

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1713537308,
+        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713062877,
-        "narHash": "sha256-msvDk9+qkD4jvMf63PieGRy+hHk0VIKruivHM1BmCM8=",
+        "lastModified": 1713579131,
+        "narHash": "sha256-j/lrqFNzm7SdlBlKX43kA2Wp0OaGVOUjQGnER9//4Ao=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5990088d56f0b936fa2633c2a4d76b8d36a01105",
+        "rev": "67e961704b80454f1ba6595b02e26afc9af4cdce",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             pkgs.mkShell {
               packages = with pkgs; [
                 cargo-release
+                cargo-llvm-cov
               ] ++ [ rust-toolchain ];
             };
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2024-04-20"
 components = ["rust-src", "rust-analyzer"]

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -1,0 +1,1 @@
+mod u8_slice;

--- a/src/impls/u8_slice.rs
+++ b/src/impls/u8_slice.rs
@@ -1,0 +1,255 @@
+use std::io::IoSliceMut;
+use std::{cmp, io::Read};
+
+use crate::RevBufRead;
+use crate::{rev_read_borrowed_buf::RevBorrowedCursor, RevRead};
+
+/// As for the [`Read`] implementation of `&[u8]`, bytes get copied from the slice.
+///
+/// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html#impl-Read-for-%26%5Bu8%5D
+impl RevRead for &[u8] {
+    fn rev_read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let buf_len = buf.len();
+        let self_len = self.len();
+
+        let amount = cmp::min(buf_len, self_len);
+        let (tail, head) = self.split_at(self_len - amount);
+
+        if amount == 1 {
+            // SAFETY:
+            //  - If amount == 1 == buf.len(), then there's at least one value!
+            //  - If buf.len() < 1 => amount < 1 as well => not possible
+            //  - otherwise buf.len() > 1
+            let buf_last = buf.last_mut().unwrap();
+            // SAFETY:
+            //  - If amount == 1 == self.len(), then `tail` would be empty and `head` would get the value
+            //  - If self.len() < 1 => amount < 1 as well => not possible
+            //  - otherwise self.len() > 1
+            let head_last = head.last().unwrap();
+
+            *buf_last = *head_last;
+        } else {
+            buf[buf_len - amount..].copy_from_slice(head);
+        }
+
+        *self = tail;
+
+        Ok(amount)
+    }
+
+    fn rev_read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> std::io::Result<usize> {
+        let mut amount_read = 0;
+        for buf in bufs {
+            amount_read += self.rev_read(buf)?;
+            if self.is_empty() {
+                break;
+            }
+        }
+
+        Ok(amount_read)
+    }
+
+    #[inline]
+    fn rev_is_read_vectored(&self) -> bool {
+        true
+    }
+
+    fn rev_read_to_end(&mut self, buf: &mut Vec<u8>) -> std::io::Result<usize> {
+        let len = self.len();
+        buf.try_reserve(len)
+            .map_err(|_| std::io::ErrorKind::OutOfMemory)?;
+
+        let mut new_vec = self.to_vec();
+        new_vec.extend_from_slice(buf);
+        *buf = new_vec;
+
+        *self = &[];
+
+        Ok(len)
+    }
+
+    fn rev_read_to_string(&mut self, buf: &mut String) -> std::io::Result<usize> {
+        // validating the bytes from right to left or left to right doesn't differ
+        self.read_to_string(buf)
+    }
+
+    fn rev_read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        if buf.len() > self.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ));
+        }
+
+        let (tail, head) = self.split_at(self.len() - buf.len());
+
+        if buf.len() == 1 {
+            let last_buf_value = buf.last_mut().unwrap();
+            *last_buf_value = *head.last().unwrap();
+        } else {
+            let head_len = head.len();
+            buf.copy_from_slice(&head[head_len - buf.len()..]);
+        }
+
+        *self = tail;
+
+        Ok(())
+    }
+
+    fn rev_read_buf(&mut self, mut cursor: RevBorrowedCursor<'_>) -> std::io::Result<()> {
+        let amount = cmp::min(cursor.capacity(), self.len());
+        let (tail, head) = self.split_at(self.len() - amount);
+
+        cursor.append(head);
+
+        *self = tail;
+        Ok(())
+    }
+}
+
+impl RevBufRead for &[u8] {
+    fn rev_fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        Ok(*self)
+    }
+
+    fn rev_consume(&mut self, amt: usize) {
+        let end = self.len().saturating_sub(amt);
+        *self = &self[..end];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RevRead;
+
+    mod rev_read {
+        use super::RevRead;
+
+        #[test]
+        fn amount_1() {
+            let values = [1, 2, 3];
+            let mut buffer = [0];
+
+            assert_eq!(values.as_slice().rev_read(&mut buffer).ok(), Some(1));
+            assert_eq!(buffer, [3]);
+        }
+
+        #[test]
+        fn multiple() {
+            let values = [1, 2, 3];
+            let mut buffer = [0, 0];
+
+            assert_eq!(values.as_slice().rev_read(&mut buffer).ok(), Some(2));
+            assert_eq!(buffer, [2, 3]);
+        }
+
+        #[test]
+        fn bigger_buffer_than_self() {
+            let values = [1, 2, 3];
+            let mut buffer = [0, 0, 0, 0];
+
+            assert_eq!(values.as_slice().rev_read(&mut buffer).ok(), Some(3));
+            assert_eq!(buffer, [0, 1, 2, 3]);
+        }
+    }
+
+    mod rev_read_buf {
+        use super::RevRead;
+        use crate::RevBorrowedBuf;
+
+        #[test]
+        fn empty_cursor() {
+            let values: [u8; 3] = [1, 2, 3];
+            let mut buffer: [u8; 0] = [];
+            let mut borrowed_buf = RevBorrowedBuf::from(buffer.as_mut_slice());
+            let cursor = borrowed_buf.unfilled();
+
+            assert!(values.as_slice().rev_read_buf(cursor).is_ok());
+        }
+
+        #[test]
+        fn normal_cursor() {
+            let values: [u8; 3] = [1, 2, 3];
+            let mut buffer: [u8; 2] = [0, 0];
+            let mut borrowed_buf = RevBorrowedBuf::from(buffer.as_mut_slice());
+            let cursor = borrowed_buf.unfilled();
+
+            assert!(values.as_slice().rev_read_buf(cursor).is_ok());
+            assert_eq!(buffer, [2, 3]);
+        }
+
+        #[test]
+        fn cursor_longer_than_values() {
+            let values: [u8; 3] = [1, 2, 3];
+            let mut buffer: [u8; 4] = [0, 0, 0, 0];
+            let mut borrowed_buf = RevBorrowedBuf::from(buffer.as_mut_slice());
+            let cursor = borrowed_buf.unfilled();
+
+            assert!(values.as_slice().rev_read_buf(cursor).is_ok());
+            assert_eq!(buffer, [0, 1, 2, 3]);
+        }
+    }
+
+    mod rev_read_exact {
+        use super::RevRead;
+        #[test]
+        fn empty_buf() {
+            let values = [1, 2, 3];
+            let mut buffer = [];
+
+            assert!(values.as_slice().rev_read_exact(&mut buffer).is_ok());
+        }
+
+        #[test]
+        fn normal() {
+            let values = [1, 2, 3];
+            let mut buffer = [0, 0];
+
+            assert!(values.as_slice().rev_read_exact(&mut buffer).is_ok());
+            assert_eq!(buffer, [2, 3]);
+        }
+
+        #[test]
+        fn equal_size() {
+            let values = [1, 2, 3];
+            let mut buffer = [0, 0, 0];
+
+            assert!(values.as_slice().rev_read_exact(&mut buffer).is_ok());
+            assert_eq!(buffer, [1, 2, 3]);
+        }
+    }
+
+    mod rev_read_to_end {
+        use super::RevRead;
+        #[test]
+        fn empty_vec() {
+            let values = [1, 2, 3];
+            let mut buffer = vec![];
+
+            assert_eq!(values.as_slice().rev_read_to_end(&mut buffer).ok(), Some(3));
+            assert_eq!(buffer.as_slice(), &[1, 2, 3]);
+        }
+
+        #[test]
+        fn non_empty_vec() {
+            let values = [1, 2, 3];
+            let mut buffer = vec![4];
+
+            assert_eq!(values.as_slice().rev_read_to_end(&mut buffer).ok(), Some(3));
+            assert_eq!(buffer.as_slice(), &[1, 2, 3, 4]);
+        }
+    }
+
+    mod rev_buf_read {
+        use crate::RevBufRead;
+
+        #[test]
+        fn rev_consume_large_amt() {
+            let values: [u8; 3] = [1, 2, 3];
+            let mut reference: &[u8] = &values;
+
+            reference.rev_consume(values.len() + 1);
+            assert!(reference.is_empty());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,21 @@
+// #![feature(core_io_borrowed_buf)]
+#![feature(new_uninit)]
+#![feature(maybe_uninit_slice)]
+#![feature(maybe_uninit_write_slice)]
+#![feature(read_buf)]
+#![feature(ptr_as_uninit)]
 
+mod impls;
+mod rev_read;
+mod rev_read_borrowed_buf;
+
+// Bare metal platforms usually have very small amounts of RAM
+// (in the order of hundreds of KB)
+pub const DEFAULT_BUF_SIZE: usize = if cfg!(target_os = "espidf") {
+    512
+} else {
+    8 * 1024
+};
+
+pub use rev_read::{RevBufRead, RevRead};
+pub use rev_read_borrowed_buf::{RevBorrowedBuf, RevBorrowedCursor};

--- a/src/rev_read.rs
+++ b/src/rev_read.rs
@@ -1,0 +1,619 @@
+use std::{
+    cmp,
+    io::{self, ErrorKind, IoSliceMut, Result},
+    slice,
+};
+
+use crate::{rev_read_borrowed_buf::RevBorrowedCursor, RevBorrowedBuf};
+
+/// Equals the [std::io::Read] trait, except that everything is in reverse.
+pub trait RevRead {
+    fn rev_read(&mut self, buf: &mut [u8]) -> Result<usize>;
+
+    fn rev_read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
+        default_rev_read_vectored(|b| self.rev_read(b), bufs)
+    }
+    fn rev_is_read_vectored(&self) -> bool {
+        false
+    }
+    fn rev_read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        default_rev_read_to_end(self, buf, None)
+    }
+    fn rev_read_to_string(&mut self, buf: &mut String) -> Result<usize> {
+        default_rev_read_to_string(self, buf, None)
+    }
+    fn rev_read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        default_rev_read_exact(self, buf)
+    }
+    fn rev_read_buf(&mut self, cursor: RevBorrowedCursor<'_>) -> Result<()> {
+        default_rev_read_buf(|b| self.rev_read(b), cursor)
+    }
+    fn rev_read_buf_exact(&mut self, cursor: RevBorrowedCursor<'_>) -> Result<()> {
+        default_rev_read_buf_exact(self, cursor)
+    }
+    fn rev_by_ref(&mut self) -> &mut Self
+    where
+        Self: Sized,
+    {
+        self
+    }
+    fn rev_bytes(self) -> Bytes<Self>
+    where
+        Self: Sized,
+    {
+        Bytes { inner: self }
+    }
+    fn rev_chain<R: io::Read>(self, next: R) -> Chain<Self, R>
+    where
+        Self: Sized,
+    {
+        Chain {
+            first: self,
+            second: next,
+            done_first: false,
+        }
+    }
+    fn rev_take(self, limit: u64) -> Take<Self>
+    where
+        Self: Sized,
+    {
+        Take { inner: self, limit }
+    }
+}
+
+/// Equals the [std::io::BufRead] trait, except that everything is in reverse.
+pub trait RevBufRead: RevRead {
+    fn rev_fill_buf(&mut self) -> io::Result<&[u8]>;
+
+    fn rev_consume(&mut self, amt: usize);
+
+    // Provided methods
+    fn rev_has_data_left(&mut self) -> io::Result<bool> {
+        todo!()
+    }
+
+    fn rev_read_until(&mut self, _byte: u8, _buf: &mut Vec<u8>) -> io::Result<usize> {
+        todo!()
+    }
+
+    fn rev_skip_until(&mut self, _byte: u8) -> io::Result<usize> {
+        todo!()
+    }
+
+    fn rev_read_line(&mut self, _buf: &mut String) -> io::Result<usize> {
+        todo!()
+    }
+
+    fn rev_split(self, _byte: u8) -> Split<Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn rev_lines(self) -> Lines<Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+}
+
+/// An iterator over `u8` values of a reader.
+///
+/// This struct is generally created by calling [`bytes`] on a reader.
+/// Please see the documentation of [`bytes`] for more details.
+///
+/// [`bytes`]: Read::bytes
+#[derive(Debug)]
+pub struct Bytes<R> {
+    pub inner: R,
+}
+
+impl<R: RevRead> Iterator for Bytes<R> {
+    type Item = Result<u8>;
+
+    // Not `#[inline]`. This function gets inlined even without it, but having
+    // the inline annotation can result in worse code generation. See #116785.
+    fn next(&mut self) -> Option<Result<u8>> {
+        SpecReadByte::spec_read_byte(&mut self.inner)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        SizeHint::size_hint(&self.inner)
+    }
+}
+
+/// For the specialization of `Bytes::next`.
+trait SpecReadByte {
+    fn spec_read_byte(&mut self) -> Option<Result<u8>>;
+}
+
+impl<R> SpecReadByte for R
+where
+    Self: RevRead,
+{
+    #[inline]
+    fn spec_read_byte(&mut self) -> Option<Result<u8>> {
+        inlined_slow_read_byte(self)
+    }
+}
+
+trait SizeHint {
+    fn lower_bound(&self) -> usize;
+
+    fn upper_bound(&self) -> Option<usize>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.lower_bound(), self.upper_bound())
+    }
+}
+
+impl<T: ?Sized> SizeHint for T {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        None
+    }
+}
+
+/// Read a single byte in a slow, generic way. This is used by the default
+/// `spec_read_byte`.
+#[inline]
+fn inlined_slow_read_byte<R: RevRead>(reader: &mut R) -> Option<Result<u8>> {
+    let mut byte = 0;
+    loop {
+        return match reader.rev_read(slice::from_mut(&mut byte)) {
+            Ok(0) => None,
+            Ok(..) => Some(Ok(byte)),
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+            Err(e) => Some(Err(e)),
+        };
+    }
+}
+
+/// Adapter to chain together two readers.
+///
+/// This struct is generally created by calling [`chain`] on a reader.
+/// Please see the documentation of [`chain`] for more details.
+///
+/// [`chain`]: Read::chain
+#[derive(Debug)]
+pub struct Chain<T, U> {
+    first: T,
+    second: U,
+    done_first: bool,
+}
+
+impl<T, U> Chain<T, U> {
+    /// Consumes the `Chain`, returning the wrapped readers.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut foo_file = File::open("foo.txt")?;
+    ///     let mut bar_file = File::open("bar.txt")?;
+    ///
+    ///     let chain = foo_file.chain(bar_file);
+    ///     let (foo_file, bar_file) = chain.into_inner();
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn into_inner(self) -> (T, U) {
+        (self.first, self.second)
+    }
+
+    /// Gets references to the underlying readers in this `Chain`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut foo_file = File::open("foo.txt")?;
+    ///     let mut bar_file = File::open("bar.txt")?;
+    ///
+    ///     let chain = foo_file.chain(bar_file);
+    ///     let (foo_file, bar_file) = chain.get_ref();
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_ref(&self) -> (&T, &U) {
+        (&self.first, &self.second)
+    }
+
+    /// Gets mutable references to the underlying readers in this `Chain`.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying readers as doing so may corrupt the internal state of this
+    /// `Chain`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut foo_file = File::open("foo.txt")?;
+    ///     let mut bar_file = File::open("bar.txt")?;
+    ///
+    ///     let mut chain = foo_file.chain(bar_file);
+    ///     let (foo_file, bar_file) = chain.get_mut();
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_mut(&mut self) -> (&mut T, &mut U) {
+        (&mut self.first, &mut self.second)
+    }
+}
+
+impl<T: RevRead, U: RevRead> RevRead for Chain<T, U> {
+    fn rev_read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        if !self.done_first {
+            match self.first.rev_read(buf)? {
+                0 if !buf.is_empty() => self.done_first = true,
+                n => return Ok(n),
+            }
+        }
+        self.second.rev_read(buf)
+    }
+
+    fn rev_read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
+        if !self.done_first {
+            match self.first.rev_read_vectored(bufs)? {
+                0 if bufs.iter().any(|b| !b.is_empty()) => self.done_first = true,
+                n => return Ok(n),
+            }
+        }
+        self.second.rev_read_vectored(bufs)
+    }
+
+    #[inline]
+    fn rev_is_read_vectored(&self) -> bool {
+        self.first.rev_is_read_vectored() || self.second.rev_is_read_vectored()
+    }
+
+    fn rev_read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        let mut read = 0;
+        if !self.done_first {
+            read += self.first.rev_read_to_end(buf)?;
+            self.done_first = true;
+        }
+        read += self.second.rev_read_to_end(buf)?;
+        Ok(read)
+    }
+
+    // We don't override `read_to_string` here because an UTF-8 sequence could
+    // be split between the two parts of the chain
+    fn rev_read_buf(&mut self, mut buf: RevBorrowedCursor<'_>) -> Result<()> {
+        if buf.capacity() == 0 {
+            return Ok(());
+        }
+
+        if !self.done_first {
+            let old_len = buf.written();
+            self.first.rev_read_buf(buf.reborrow())?;
+
+            if buf.written() != old_len {
+                return Ok(());
+            } else {
+                self.done_first = true;
+            }
+        }
+        self.second.rev_read_buf(buf)
+    }
+}
+
+impl<T: RevBufRead, U: RevBufRead> RevBufRead for Chain<T, U> {
+    fn rev_fill_buf(&mut self) -> Result<&[u8]> {
+        if !self.done_first {
+            match self.first.rev_fill_buf()? {
+                [] => self.done_first = true,
+                buf => return Ok(buf),
+            }
+        }
+        self.second.rev_fill_buf()
+    }
+
+    fn rev_consume(&mut self, amt: usize) {
+        if !self.done_first {
+            self.first.rev_consume(amt)
+        } else {
+            self.second.rev_consume(amt)
+        }
+    }
+
+    fn rev_read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
+        let mut read = 0;
+        if !self.done_first {
+            let n = self.first.rev_read_until(byte, buf)?;
+            read += n;
+
+            match buf.last() {
+                Some(b) if *b == byte && n != 0 => return Ok(read),
+                _ => self.done_first = true,
+            }
+        }
+        read += self.second.rev_read_until(byte, buf)?;
+        Ok(read)
+    }
+}
+
+/// An iterator over the contents of an instance of `BufRead` split on a
+/// particular byte.
+///
+/// This struct is generally created by calling [`split`] on a `BufRead`.
+/// Please see the documentation of [`split`] for more details.
+///
+/// [`split`]: BufRead::split
+#[derive(Debug)]
+pub struct Split<B> {
+    buf: B,
+    delim: u8,
+}
+
+impl<B: RevBufRead> Iterator for Split<B> {
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Result<Vec<u8>>> {
+        let mut buf = Vec::new();
+        match self.buf.rev_read_until(self.delim, &mut buf) {
+            Ok(0) => None,
+            Ok(_n) => {
+                if buf[buf.len() - 1] == self.delim {
+                    buf.pop();
+                }
+                Some(Ok(buf))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+/// An iterator over the lines of an instance of `BufRead`.
+///
+/// This struct is generally created by calling [`lines`] on a `BufRead`.
+/// Please see the documentation of [`lines`] for more details.
+///
+/// [`lines`]: BufRead::lines
+#[derive(Debug)]
+pub struct Lines<B> {
+    buf: B,
+}
+
+impl<B: RevBufRead> Iterator for Lines<B> {
+    type Item = Result<String>;
+
+    fn next(&mut self) -> Option<Result<String>> {
+        let mut buf = String::new();
+        match self.buf.rev_read_line(&mut buf) {
+            Ok(0) => None,
+            Ok(_n) => {
+                if buf.ends_with('\n') {
+                    buf.pop();
+                    if buf.ends_with('\r') {
+                        buf.pop();
+                    }
+                }
+                Some(Ok(buf))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+/// Reader adapter which limits the bytes read from an underlying reader.
+///
+/// This struct is generally created by calling [`take`] on a reader.
+/// Please see the documentation of [`take`] for more details.
+///
+/// [`take`]: Read::take
+#[derive(Debug)]
+pub struct Take<T> {
+    inner: T,
+    limit: u64,
+}
+
+impl<T> Take<T> {
+    pub fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    pub fn set_limit(&mut self, limit: u64) {
+        self.limit = limit;
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: RevRead> RevRead for Take<T> {
+    fn rev_read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        // Don't call into inner reader at all at EOF because it may still block
+        if self.limit == 0 {
+            return Ok(0);
+        }
+
+        let max = cmp::min(buf.len() as u64, self.limit) as usize;
+        let n = self.inner.rev_read(&mut buf[..max])?;
+        assert!(n as u64 <= self.limit, "number of read bytes exceeds limit");
+        self.limit -= n as u64;
+        Ok(n)
+    }
+
+    fn rev_read_buf(&mut self, mut buf: RevBorrowedCursor<'_>) -> Result<()> {
+        // Don't call into inner reader at all at EOF because it may still block
+        if self.limit == 0 {
+            return Ok(());
+        }
+
+        if self.limit <= buf.capacity() as u64 {
+            // if we just use an as cast to convert, limit may wrap around on a 32 bit target
+            let limit = cmp::min(self.limit, usize::MAX as u64) as usize;
+
+            let extra_init = cmp::min(limit as usize, buf.init_ref().len());
+
+            // SAFETY: no uninit data is written to ibuf
+            let ibuf = unsafe { &mut buf.as_mut()[..limit] };
+
+            let mut sliced_buf: RevBorrowedBuf<'_> = ibuf.into();
+
+            // SAFETY: extra_init bytes of ibuf are known to be initialized
+            unsafe {
+                sliced_buf.set_init(extra_init);
+            }
+
+            let mut cursor = sliced_buf.unfilled();
+            self.inner.rev_read_buf(cursor.reborrow())?;
+
+            let new_init = cursor.init_ref().len();
+            let filled = sliced_buf.len();
+
+            // cursor / sliced_buf / ibuf must drop here
+
+            unsafe {
+                // SAFETY: filled bytes have been filled and therefore initialized
+                buf.advance(filled);
+                // SAFETY: new_init bytes of buf's unfilled buffer have been initialized
+                buf.set_init(new_init);
+            }
+
+            self.limit -= filled as u64;
+        } else {
+            let written = buf.written();
+            self.inner.rev_read_buf(buf.reborrow())?;
+            self.limit -= (buf.written() - written) as u64;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: RevBufRead> RevBufRead for Take<T> {
+    fn rev_fill_buf(&mut self) -> Result<&[u8]> {
+        // Don't call into inner reader at all at EOF because it may still block
+        if self.limit == 0 {
+            return Ok(&[]);
+        }
+
+        let buf = self.inner.rev_fill_buf()?;
+        let cap = cmp::min(buf.len() as u64, self.limit) as usize;
+        Ok(&buf[..cap])
+    }
+
+    fn rev_consume(&mut self, amt: usize) {
+        // Don't let callers reset the limit by passing an overlarge value
+        let amt = cmp::min(amt as u64, self.limit) as usize;
+        self.limit -= amt as u64;
+        self.inner.rev_consume(amt);
+    }
+}
+
+/// == default implementations ==
+pub fn default_rev_read_vectored<F>(rev_read: F, bufs: &mut [IoSliceMut<'_>]) -> Result<usize>
+where
+    F: FnOnce(&mut [u8]) -> Result<usize>,
+{
+    let buf = bufs
+        .iter_mut()
+        .find(|b| !b.is_empty())
+        .map_or(&mut [][..], |b| &mut **b);
+    rev_read(buf)
+}
+
+pub fn default_rev_read_to_end<R: RevRead + ?Sized>(
+    _r: &mut R,
+    _buf: &mut [u8],
+    _size_hint: Option<usize>,
+) -> Result<usize> {
+    todo!()
+}
+
+pub fn default_rev_read_to_string<R: RevRead + ?Sized>(
+    _r: &mut R,
+    _buf: &mut str,
+    _size_hint: Option<usize>,
+) -> Result<usize> {
+    todo!()
+}
+
+pub fn default_rev_read_exact<R: RevRead + ?Sized>(this: &mut R, mut buf: &mut [u8]) -> Result<()> {
+    while !buf.is_empty() {
+        match this.rev_read(buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                let buf_len = buf.len();
+                buf = &mut buf[..buf_len - n];
+            }
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    if !buf.is_empty() {
+        Err(std::io::Error::new(
+            ErrorKind::UnexpectedEof,
+            "failed to fill whole buffer",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn default_rev_read_buf<F>(read: F, mut cursor: RevBorrowedCursor<'_>) -> Result<()>
+where
+    F: FnOnce(&mut [u8]) -> Result<usize>,
+{
+    let n = read(cursor.ensure_init().init_mut())?;
+    unsafe {
+        // SAFETY: we initialised using `ensure_init` so there is no uninit data to advance to.
+        cursor.advance(n);
+    }
+    Ok(())
+}
+
+pub fn default_rev_read_buf_exact<R: RevRead + ?Sized>(
+    read: &mut R,
+    mut cursor: RevBorrowedCursor<'_>,
+) -> Result<()> {
+    while cursor.capacity() > 0 {
+        let prev_written = cursor.written();
+        match read.rev_read_buf(cursor.reborrow()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+
+        if cursor.written() == prev_written {
+            return Err(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill buffer",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/src/rev_read_borrowed_buf.rs
+++ b/src/rev_read_borrowed_buf.rs
@@ -1,0 +1,377 @@
+use std::mem::{self, MaybeUninit};
+use std::{cmp, ptr};
+
+/// A borrowed byte buffer which is incrementally filled and initialized. This is basically just the reversed version of
+/// [`std::io::BorrowedBuf`].
+///
+/// This type is a sort of "double cursor". It tracks three regions in the buffer:
+/// - a region at the beginning of the buffer that is fully uninitialized
+/// - a region that has been initialized at some point but not yet logically filled, and
+/// - a region at the end that is fully initilized. The filled region is guaranteed to be a
+/// subset of the initialized region.
+///
+/// In summary, the contents of the buffer can be visualized as:
+/// ```not_rust
+/// [             capacity              ]
+/// [ unfilled |         filled         ]
+/// [    uninitialized    | initialized ]
+/// ```
+///
+/// A `RevBorrowedBuf` is created around some existing data (or capacity for data) via a unique reference
+/// (`&mut`). The `RevBorrowedBuf` can be configured (e.g., using `clear` or `set_init`), but cannot be
+/// directly written. To write into the buffer, use `unfilled` to create a `RevBorrowedCursor`. The cursor
+/// has write-only access to the unfilled portion of the buffer (you can think of it as a
+/// write-only iterator).
+///
+/// The lifetime `'data` is a bound on the lifetime of the underlying data.
+#[derive(Debug)]
+pub struct RevBorrowedBuf<'data> {
+    /// The buffer's underlying data.
+    buf: &'data mut [MaybeUninit<u8>],
+    /// The starting index (inclusively) where the values are filled
+    filled: usize,
+    /// The starting index (inclusively) where the values are initialized
+    init: usize,
+}
+
+/// Create a new `RevBorrowedBuf` from a fully initialized slice.
+impl<'data> From<&'data mut [u8]> for RevBorrowedBuf<'data> {
+    #[inline]
+    fn from(slice: &'data mut [u8]) -> RevBorrowedBuf<'data> {
+        let len = slice.len();
+
+        RevBorrowedBuf {
+            // SAFETY: initialized data never becoming uninitialized is an invariant of BorrowedBuf
+            buf: unsafe { (slice as *mut [u8]).as_uninit_slice_mut().unwrap() },
+            filled: len,
+            init: 0,
+        }
+    }
+}
+
+/// Create a new `RevBorrowedBuf` from an uninitialized buffer.
+///
+/// Use `set_init` if part of the buffer is known to be already initialized.
+impl<'data> From<&'data mut [MaybeUninit<u8>]> for RevBorrowedBuf<'data> {
+    #[inline]
+    fn from(buf: &'data mut [MaybeUninit<u8>]) -> RevBorrowedBuf<'data> {
+        let len = buf.len();
+        RevBorrowedBuf {
+            buf,
+            filled: len,
+            init: len,
+        }
+    }
+}
+
+impl<'data> RevBorrowedBuf<'data> {
+    /// Returns the total capacity of the buffer.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns the amount of bytes which are filled.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.capacity() - self.filled
+    }
+
+    /// Returns `true` if the buf is empty, otherwise `false`.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.buf.len() == 0
+    }
+
+    /// Returns the amount of bytes of the initialized part of the buffer.
+    #[inline]
+    pub fn init_len(&self) -> usize {
+        self.capacity() - self.init
+    }
+
+    /// Returns a shared reference to the filled portion of the buffer.
+    #[inline]
+    pub fn filled(&self) -> &[u8] {
+        // SAFETY: We only slice the filled part of the buffer, which is always valid
+        unsafe { MaybeUninit::slice_assume_init_ref(&self.buf[self.filled..]) }
+    }
+
+    /// Returns a mutable reference to the filled portion of the buffer.
+    #[inline]
+    pub fn filled_mut(&mut self) -> &mut [u8] {
+        // SAFETY: We only slice the filled part of the buffer, which is always valid
+        unsafe { MaybeUninit::slice_assume_init_mut(&mut self.buf[self.filled..]) }
+    }
+
+    /// Returns a cursor over the unfilled part of the buffer.
+    #[inline]
+    pub fn unfilled<'this>(&'this mut self) -> RevBorrowedCursor<'this> {
+        RevBorrowedCursor {
+            start: self.filled,
+            // SAFETY: we never assign into `RevBorrowedCursor::buf`, so treating its
+            // lifetime covariantly is safe.
+            buf: unsafe {
+                mem::transmute::<&'this mut RevBorrowedBuf<'data>, &'this mut RevBorrowedBuf<'this>>(
+                    self,
+                )
+            },
+        }
+    }
+
+    /// Clears the buffer, resetting the filled region to empty.
+    ///
+    /// The number of initialized bytes is not changed, and the contents of the buffer are not modified.
+    #[inline]
+    pub fn clear(&mut self) -> &mut Self {
+        self.filled = self.capacity();
+        self
+    }
+
+    /// Asserts that all bytes on the left (inclusive) to index `n` are initialised.
+    ///
+    /// `RevBorrowedBuf` assumes that bytes are never de-initialized, so this method does nothing when called with fewer
+    /// bytes than are already known to be initialized.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the last `n` unfilled bytes of the buffer have already been initialized.
+    #[inline]
+    pub unsafe fn set_init(&mut self, n: usize) -> &mut Self {
+        self.init = cmp::min(self.init, n);
+        self
+    }
+}
+
+/// A writeable view of the unfilled portion of a [`RevBorrowedBuf`](RevBorrowedBuf).
+///
+/// Provides access to the initialized and uninitialized parts of the underlying `RevBorrowedBuf`.
+/// Data can be written directly to the cursor by using [`append`](RevBorrowedCursor::append) or
+/// indirectly by getting a slice of part or all of the cursor and writing into the slice. In the
+/// indirect case, the caller must call [`advance`](RevBorrowedCursor::advance) after writing to inform
+/// the cursor how many bytes have been written.
+///
+/// Once data is written to the cursor, it becomes part of the filled portion of the underlying
+/// `RevBorrowedBuf` and can no longer be accessed or re-written by the cursor. I.e., the cursor tracks
+/// the unfilled part of the underlying `RevBorrowedBuf`.
+///
+/// The lifetime `'a` is a bound on the lifetime of the underlying buffer (which means it is a bound
+/// on the data in that buffer by transitivity).
+#[derive(Debug)]
+pub struct RevBorrowedCursor<'a> {
+    /// The underlying buffer.
+    // Safety invariant: we treat the type of buf as covariant in the lifetime of `RevBorrowedBuf` when
+    // we create a `BorrowedCursor`. This is only safe if we never replace `buf` by assigning into
+    // it, so don't do that!
+    buf: &'a mut RevBorrowedBuf<'a>,
+    /// The length of the filled portion of the underlying buffer at the time of the cursor's
+    /// creation.
+    /// It applies: `self.buf.filled` <= `self.start`
+    start: usize,
+}
+
+impl<'a> RevBorrowedCursor<'a> {
+    /// Reborrow this cursor by cloning it with a smaller lifetime.
+    ///
+    /// Since a cursor maintains unique access to its underlying buffer, the borrowed cursor is
+    /// not accessible while the new cursor exists.
+    #[inline]
+    pub fn reborrow<'this>(&'this mut self) -> RevBorrowedCursor<'this> {
+        RevBorrowedCursor {
+            // SAFETY: we never assign into `BorrowedCursor::buf`, so treating its
+            // lifetime covariantly is safe.
+            buf: unsafe {
+                mem::transmute::<&'this mut RevBorrowedBuf<'a>, &'this mut RevBorrowedBuf<'this>>(
+                    self.buf,
+                )
+            },
+            start: self.start,
+        }
+    }
+
+    /// Returns the available space in the cursor.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.buf.filled
+    }
+
+    /// Returns the number of bytes written to this cursor since it was created from a `RevBorrowedBuf`.
+    ///
+    /// Note that if this cursor is a reborrowed clone of another, then the count returned is the
+    /// count written via either cursor, not the count since the cursor was reborrowed.
+    #[inline]
+    pub fn written(&self) -> usize {
+        self.start - self.buf.filled
+    }
+
+    /// Returns a shared reference to the initialized portion of the cursor.
+    #[inline]
+    pub fn init_ref(&self) -> &[u8] {
+        debug_assert!(self.buf.init <= self.buf.filled);
+
+        // SAFETY: We only slice the initialized part of the buffer, which is always valid
+        unsafe { MaybeUninit::slice_assume_init_ref(&self.buf.buf[self.buf.init..]) }
+    }
+
+    /// Returns a mutable reference to the initialized portion of the cursor.
+    #[inline]
+    pub fn init_mut(&mut self) -> &mut [u8] {
+        debug_assert!(self.buf.init <= self.buf.filled);
+
+        // SAFETY: We only slice the initialized part of the buffer, which is always valid
+        unsafe { MaybeUninit::slice_assume_init_mut(&mut self.buf.buf[self.buf.init..]) }
+    }
+
+    /// Returns a mutable reference to the uninitialized part of the cursor.
+    ///
+    /// It is safe to uninitialize any of these bytes.
+    #[inline]
+    pub fn uninit_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        &mut self.buf.buf[..self.buf.init]
+    }
+
+    /// Returns a mutable reference to the whole cursor.
+    ///
+    /// # Safety
+    ///
+    /// The caller must not uninitialize any bytes in the initialized portion of the cursor.
+    #[inline]
+    pub unsafe fn as_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        &mut self.buf.buf[..self.buf.filled]
+    }
+
+    /// Advance the cursor by asserting that `n` bytes have been filled.
+    ///
+    /// After advancing, the `n` bytes are no longer accessible via the cursor and can only be
+    /// accessed via the underlying buffer. I.e., the buffer's filled portion grows by `n` elements
+    /// and its unfilled portion (and the capacity of this cursor) shrinks by `n` elements.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the first `n` bytes of the cursor have been properly
+    /// initialised.
+    #[inline]
+    pub unsafe fn advance(&mut self, n: usize) -> &mut Self {
+        self.buf.filled -= n;
+        self.buf.init = cmp::min(self.buf.init, self.buf.filled);
+        self
+    }
+
+    /// Initializes all bytes in the cursor.
+    #[inline]
+    pub fn ensure_init(&mut self) -> &mut Self {
+        let uninit = self.uninit_mut();
+        // SAFETY: 0 is a valid value for MaybeUninit<u8> and the length matches the allocation
+        // since it is comes from a slice reference.
+        unsafe {
+            ptr::write_bytes(uninit.as_mut_ptr(), 0, uninit.len());
+        }
+        self.buf.init = 0;
+
+        self
+    }
+
+    /// Asserts that the first `n` unfilled bytes of the cursor are initialized.
+    ///
+    /// `RevBorrowedBuf` assumes that bytes are never de-initialized, so this method does nothing when
+    /// called with fewer bytes than are already known to be initialized.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the first `n` bytes of the buffer have already been initialized.
+    #[inline]
+    pub unsafe fn set_init(&mut self, n: usize) -> &mut Self {
+        self.buf.init = cmp::min(self.buf.init, self.buf.filled - n);
+        self
+    }
+
+    /// Appends data to the cursor, advancing position within its buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.capacity()` is less than `buf.len()`.
+    #[inline]
+    pub fn append(&mut self, buf: &[u8]) {
+        assert!(self.capacity() >= buf.len());
+
+        // SAFETY: we do not de-initialize any of the elements of the slice
+        let mut_init_slice = unsafe { self.as_mut() };
+        let mut_init_slice_len = mut_init_slice.len();
+        MaybeUninit::copy_from_slice(
+            &mut mut_init_slice[mut_init_slice_len.saturating_sub(buf.len())..],
+            buf,
+        );
+
+        // SAFETY: We just added the entire contents of buf to the filled section.
+        unsafe {
+            self.set_init(buf.len());
+        }
+        self.buf.filled -= buf.len();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod rev_borrowed_buf {
+        use super::*;
+
+        #[test]
+        fn filled() {
+            let mut data = [1, 2, 3];
+            let mut buf = RevBorrowedBuf::from(data.as_mut_slice());
+
+            // assume, we filled one value
+            buf.filled -= 1;
+            assert_eq!(buf.filled(), [3]);
+
+            // assume, we filled two values
+            buf.filled -= 1;
+            assert_eq!(buf.filled(), [2, 3]);
+        }
+    }
+
+    mod rev_borrowed_cursor {
+        use super::*;
+
+        #[test]
+        fn capacity() {
+            let mut data = [1, 2, 3];
+            let mut buf = RevBorrowedBuf::from(data.as_mut_slice());
+
+            // assume, we filled one value
+            buf.filled -= 1;
+            let cursor = buf.unfilled();
+
+            // one value has been written to in the buffer => at most 2 values can be written next
+            assert_eq!(cursor.capacity(), 2);
+        }
+
+        #[test]
+        fn append() {
+            let mut buffer = [1, 2, 3];
+            let mut buf = RevBorrowedBuf::from(buffer.as_mut_slice());
+
+            let data = [4, 5];
+            let mut cursor = buf.unfilled();
+            cursor.append(&data);
+
+            assert_eq!(cursor.written(), data.len());
+            assert_eq!(cursor.init_ref(), [1, 4, 5]);
+            assert_eq!(cursor.capacity(), 1);
+        }
+
+        #[test]
+        #[should_panic]
+        fn append_panic() {
+            let mut buffer: [u8; 0] = [];
+            let mut buf = RevBorrowedBuf::from(buffer.as_mut_slice());
+
+            let data = [4, 5];
+            let mut cursor = buf.unfilled();
+
+            // capacity < data.len()!!!! => Panic
+            cursor.append(&data);
+        }
+    }
+}


### PR DESCRIPTION
Implements the `RevRead` trait for `&[u8]`.